### PR TITLE
Add OmnitelK Exporter Client implementation

### DIFF
--- a/exporter/omnitelk/client.go
+++ b/exporter/omnitelk/client.go
@@ -1,0 +1,66 @@
+// Copyright 2019 Omnition Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package omnitelk
+
+import (
+	"time"
+
+	omnitelpb "github.com/Omnition/omnition-opentelemetry-service/exporter/omnitelk/gen"
+)
+
+// client allows to connect to a server, get sharding config and send encoded data.
+type client interface {
+	// Connect to the server endpoint using specified number of concurrent streams.
+	// Connect must block until it succeeds or fails (and return error in that case).
+	// If caller needs to interrupt a blocked Connect call the caller must close
+	// "cancelCh" channel, in that case Connect should return as soon as possible.
+	Connect(options ConnectionOptions, cancelCh chan interface{}) error
+
+	// GetShardingConfig returns a sharding config from the server. May be called
+	// only after Connect succeeds.
+	GetShardingConfig() (*omnitelpb.ShardingConfig, error)
+
+	// Send an encoded record to the server. The record must be encoded for the shard
+	// that is passed as the second parameter (record's partition key must be in the
+	// hash key range of the shard).
+	// This function will block if it wants to apply backpressure otherwise it may
+	// return as soon as the record is queued for delivery.
+	// The result of sending will be reported via OnSendResponse or OnSendFail
+	// callbacks.
+	Send(record *omnitelpb.EncodedRecord, shard *omnitelpb.ShardDefinition)
+}
+
+// ConnectionOptions to use for the client.
+type ConnectionOptions struct {
+	// Server's address and port.
+	Endpoint string
+
+	// Number of parallel streams to use for sending ExportRequests.
+	StreamCount uint
+
+	// How often to reopen the stream to help L7 Load Balancers re-balance the traffic.
+	StreamReopenPeriod time.Duration
+
+	// Also reopen the stream after specified count of requests are sent.
+	StreamReopenRequestCount uint32
+
+	// Callback called when a response is received regarding previously sent records.
+	// Called asynchronously sometime after Send() successfully sends the record.
+	OnSendResponse func(responseToRecords []*omnitelpb.EncodedRecord, response *omnitelpb.ExportResponse)
+
+	// Callback called if the records cannot be sent for whatever reason (e.g. the
+	// records cannot be serialized).
+	OnSendFail func(failedRecords []*omnitelpb.EncodedRecord, code FailureCode)
+}

--- a/exporter/omnitelk/client_impl.go
+++ b/exporter/omnitelk/client_impl.go
@@ -1,0 +1,363 @@
+// Copyright 2019 Omnition Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package omnitelk
+
+import (
+	"container/list"
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	omnitelpb "github.com/Omnition/omnition-opentelemetry-service/exporter/omnitelk/gen"
+)
+
+// Client can connect to a server and send an ExportRequest. It uses multiple streams
+// for sending concurrently.
+type Client struct {
+	// gRPC client.
+	client omnitelpb.OmnitelKClient
+
+	options ConnectionOptions
+
+	// The streams themselves.
+	clientStreams []*clientStream
+
+	// Requests that are pending to be sent.
+	requestsToSend chan *omnitelpb.ExportRequest
+
+	logger *zap.Logger
+}
+
+var _ client = (*Client)(nil)
+
+// clientStream represent a single gRPC stream in a currently connected Client.
+type clientStream struct {
+	// Parent Client.
+	client *Client
+
+	// gRPC stream.
+	stream omnitelpb.OmnitelK_ExportClient
+
+	// Timestamp when stream was opened.
+	lastStreamOpen time.Time
+
+	// Map of requests pending acknowledgement by server. Key is request id,
+	// value is of pendingRequest type.
+	pendingAckMap map[uint64]*list.Element
+
+	// Ordered list of pending acknowledgements. Used for processing timeouts.
+	pendingAckList *list.List
+
+	// Mutex to protect the above 2 fields.
+	pendingAckMutex sync.Mutex
+
+	// If of the next request that we will send.
+	nextID uint64
+
+	// Count of requests sent since last stream opening.
+	requestsSentSinceStreamOpen uint32
+
+	// Requests that are pending to be sent.
+	requestsToSend chan *omnitelpb.ExportRequest
+}
+
+// pendingRequest is the data type we keep in pendingAckMap and pendingAckList.
+type pendingRequest struct {
+	// The request that we sent.
+	request *omnitelpb.ExportRequest
+
+	// The deadline for the response to arrive.
+	deadline time.Time
+}
+
+// NewClient creates a new Client with specified options. Call Connect() after this.
+func NewClient(logger *zap.Logger) *Client {
+	return &Client{logger: logger}
+}
+
+// Connect to the server endpoint using specified number of concurrent streams.
+// Connect must block until it succeeds or fails (and return error in that case).
+// If caller needs to interrupt a blocked Connect call the caller must close
+// cancelCh, in that case Connect should return as soon as possible.
+func (c *Client) Connect(options ConnectionOptions, cancelCh chan interface{}) error {
+	if options.StreamReopenRequestCount == 0 {
+		options.StreamReopenRequestCount = defStreamReopenRequestCount
+	}
+
+	if options.StreamReopenPeriod == 0 {
+		options.StreamReopenPeriod = defStreamReopenPeriod
+	}
+
+	c.options = options
+
+	// Set up a connection to the server. We will use blocking mode with cancellation
+	// options.
+
+	// First create a cancellable context.
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
+	// Cancel if cancelCh signal is raised.
+	go func() {
+		<-cancelCh
+		cancelFunc()
+	}()
+
+	// Now connect. This will block until connected or until cancelFunc is called.
+	conn, err := grpc.DialContext(ctx, options.Endpoint, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		return err
+	}
+
+	// Connection successful, create gRPC client.
+	c.client = omnitelpb.NewOmnitelKClient(conn)
+
+	if c.options.StreamCount < 1 {
+		// At least one stream is required.
+		c.options.StreamCount = 1
+	}
+
+	// Create queue of requests to send.
+	c.requestsToSend = make(chan *omnitelpb.ExportRequest, c.options.StreamCount)
+
+	// Create streams.
+	for i := uint(0); i < c.options.StreamCount; i++ {
+		stream, err := newClientStream(c)
+		if err != nil {
+			return err
+		}
+		c.clientStreams = append(c.clientStreams, stream)
+	}
+	return nil
+}
+
+// GetShardingConfig returns a sharding config from the server. May be called
+// only after Connect succeeds.
+func (c *Client) GetShardingConfig() (*omnitelpb.ShardingConfig, error) {
+	return c.client.GetShardingConfig(context.Background(), &omnitelpb.ConfigRequest{})
+}
+
+// Send an encoded record to the server. The record must be encoded for the shard
+// that is passed as the second parameter (record's partition key must be in the
+// has key range of the shard). The call may block if the sending queue is full.
+// This function will block if it wants to apply backpressure otherwise it may
+// return as soon as the record is queued for delivery.
+// The result of sending will be reported via OnSendResponse or OnSendFail
+// callbacks.
+func (c *Client) Send(record *omnitelpb.EncodedRecord, shard *omnitelpb.ShardDefinition) {
+	request := &omnitelpb.ExportRequest{
+		Records: []*omnitelpb.EncodedRecord{record},
+		Shard:   shard,
+	}
+
+	if c.options.StreamCount == 1 {
+		// One stream, it is faster to send request directly, bypassing the queue.
+		c.clientStreams[0].sendRequest(request)
+		return
+	}
+
+	// Make sure we have only up to c.streamCount Send calls in progress
+	// concurrently.
+	c.requestsToSend <- request
+}
+
+func newClientStream(client *Client) (*clientStream, error) {
+	c := clientStream{}
+
+	c.client = client
+	c.requestsToSend = client.requestsToSend
+
+	// Create ack pending data structures.
+	c.pendingAckMap = make(map[uint64]*list.Element)
+	c.pendingAckList = list.New()
+
+	// Open the stream.
+	if err := c.openStream(); err != nil {
+		return nil, err
+	}
+
+	// Begin sending requests.
+	go c.processSendRequests()
+
+	// Begin processing request timeouts on the background.
+	go c.processTimeouts()
+
+	return &c, nil
+}
+
+func (c *clientStream) openStream() error {
+	var err error
+	c.stream, err = c.client.client.Export(context.Background())
+	if err != nil {
+		return err
+	}
+	c.lastStreamOpen = time.Now()
+	atomic.StoreUint32(&c.requestsSentSinceStreamOpen, 0)
+
+	go c.readStream(c.stream)
+
+	return nil
+}
+
+func (c *clientStream) readStream(stream omnitelpb.OmnitelK_ExportClient) {
+	for {
+		response, err := stream.Recv()
+		if err == io.EOF {
+			// TODO: when can this happen and what do we need to do?
+			// Most likely this happens when server closes the stream. We will need
+			// to reconnect.
+			return
+		}
+		if err != nil {
+			// TODO: when can this happen and what do we need to do?
+			// Most likely this happens when server closes the stream and returns
+			// an error to RP call. We will need to reconnect.
+			// This can probably also happen when we close the stream, so need
+			// to be careful not to reconnect in that case.
+			return
+		}
+
+		c.pendingAckMutex.Lock()
+		elem, ok := c.pendingAckMap[response.Id]
+		if !ok {
+			// Response id is not found in pending requests. Should not normally happen,
+			// indicates server misbehavior.
+		} else {
+			delete(c.pendingAckMap, response.Id)
+			c.pendingAckList.Remove(elem)
+		}
+		c.pendingAckMutex.Unlock()
+
+		pr := elem.Value.(pendingRequest)
+		c.client.options.OnSendResponse(pr.request.Records, response)
+	}
+}
+
+// processTimeouts checks pending requests and fails old ones.
+func (c *clientStream) processTimeouts() {
+	// Check once per second.
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for now := range ticker.C {
+		for {
+			c.pendingAckMutex.Lock()
+
+			// Get the oldest pending request.
+			elem := c.pendingAckList.Back()
+			if elem == nil {
+				// No pending requests, nothing to do.
+				c.pendingAckMutex.Unlock()
+				break
+			}
+
+			pr := elem.Value.(pendingRequest)
+
+			// Check request deadline.
+			if pr.deadline.Before(now) {
+				// We are past deadline, need to fail the request.
+				c.pendingAckList.Remove(elem)
+				delete(c.pendingAckMap, pr.request.Id)
+				c.pendingAckMutex.Unlock()
+				c.client.options.OnSendFail(pr.request.Records, FailedNotRetryable)
+			} else {
+				c.pendingAckMutex.Unlock()
+				break
+			}
+		}
+	}
+}
+
+func (c *clientStream) processSendRequests() {
+	for request := range c.requestsToSend {
+		c.sendRequest(request)
+	}
+}
+
+func (c *clientStream) sendRequest(
+	request *omnitelpb.ExportRequest,
+) {
+	// Send the batch via stream.
+	request.Id = atomic.AddUint64(&c.nextID, 1)
+
+	pr := pendingRequest{request: request, deadline: time.Now().Add(30 * time.Second)}
+
+	// Add the ID to pendingAckMap map
+	c.pendingAckMutex.Lock()
+	elem := c.pendingAckList.PushFront(pr)
+	c.pendingAckMap[request.Id] = elem
+	c.pendingAckMutex.Unlock()
+
+	if err := c.stream.Send(request); err != nil {
+		// TODO: refactor reopening logic to happen with retries.
+		if err == io.EOF {
+			// Server closed the stream or disconnected. Try reopening the stream once.
+			time.Sleep(1 * time.Second)
+			if err = c.openStream(); err != nil {
+				c.client.logger.Error("Error opening stream", zap.Error(err))
+			}
+			// We need to re-send all requests that are not yet acknowledged.
+			c.resendPending()
+		} else {
+			c.client.logger.Error("Cannot send request", zap.Error(err))
+			c.client.options.OnSendFail(request.Records, FailedNotRetryable)
+		}
+	}
+
+	requestsSent := atomic.AddUint32(&c.requestsSentSinceStreamOpen, 1)
+
+	// Check if time to re-open the stream.
+	if requestsSent >= c.client.options.StreamReopenRequestCount ||
+		time.Since(c.lastStreamOpen) >= c.client.options.StreamReopenPeriod {
+		// Close and reopen the stream.
+		c.lastStreamOpen = time.Now()
+		err := c.stream.CloseSend()
+		if err != nil {
+			c.client.logger.Error("Cannot close stream", zap.Error(err))
+		}
+		if err = c.openStream(); err != nil {
+			c.client.logger.Error("Cannot open stream", zap.Error(err))
+		}
+		// TODO: refactor reopening logic to happen with retries.
+	}
+}
+
+// resendPending re-sends requests which are in the pending map. This is required
+// when we re-connect after connection failure.
+func (c *clientStream) resendPending() {
+	// TODO: this function is not re-entrant. If somehow we end up calling it while
+	// it is still in progress we will send duplicates of items in the pendingAckMap.
+	// Refactor this to avoid that problem.
+
+	var requests []*omnitelpb.ExportRequest
+	// Make a copy of the pending requests list.
+	c.pendingAckMutex.Lock()
+	for _, request := range c.pendingAckMap {
+		requests = append(requests, request.Value.(*omnitelpb.ExportRequest))
+	}
+	c.pendingAckMutex.Unlock()
+
+	// Mutex is unlocked asap, now we can send the requests.
+	for _, request := range requests {
+		if err := c.stream.Send(request); err != nil {
+			c.client.options.OnSendFail(request.Records, FailedNotRetryable)
+		}
+	}
+}

--- a/exporter/omnitelk/client_impl_test.go
+++ b/exporter/omnitelk/client_impl_test.go
@@ -1,0 +1,243 @@
+// Copyright 2019 Omnition Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package omnitelk
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	omnitelpb "github.com/Omnition/omnition-opentelemetry-service/exporter/omnitelk/gen"
+)
+
+func TestConnectCancellation(t *testing.T) {
+	c := NewClient(zap.NewNop())
+
+	cancelCh := make(chan interface{})
+	done := make(chan interface{})
+
+	var err error
+	go func() {
+		err = c.Connect(ConnectionOptions{
+			Endpoint: "localhost:0",
+		}, cancelCh)
+
+		close(done)
+	}()
+
+	// Signal cancellation.
+	close(cancelCh)
+
+	// Wait until cancelled.
+	<-done
+
+	// Check Connect returned an error.
+	assert.NotNil(t, err)
+}
+
+func TestConnect(t *testing.T) {
+	// Find a local address for delivery.
+	endpoint := GetAvailableLocalAddress()
+	server := mockServer{}
+
+	// Run a server
+	go runServer(&server, endpoint)
+	defer server.Stop()
+
+	// Create a client
+	client := NewClient(zap.NewNop())
+	cancelCh := make(chan interface{})
+
+	// Connect to the server
+	err := client.Connect(ConnectionOptions{
+		Endpoint: endpoint,
+	}, cancelCh)
+
+	// Make sure connection succeeded.
+	assert.Nil(t, err)
+}
+
+func TestGetConfig(t *testing.T) {
+	_, server, _ := setupClientServer(t, 0, &clientSink{})
+	server.Stop()
+}
+
+// byPartitionKey implements sort.Interface for []*omnitelpb.EncodedRecord based on
+// the PartitionKey field.
+type byPartitionKey []*omnitelpb.EncodedRecord
+
+func (a byPartitionKey) Len() int      { return len(a) }
+func (a byPartitionKey) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a byPartitionKey) Less(i, j int) bool {
+	return a[i].PartitionKey < a[j].PartitionKey
+}
+
+func TestSendRequest(t *testing.T) {
+
+	// Try with different stream counts.
+	for streamCount := uint(1); streamCount < 20; streamCount = streamCount * 2 {
+
+		func() {
+			clientSink := &clientSink{}
+			client, server, config := setupClientServer(t, streamCount, clientSink)
+			defer server.Stop()
+
+			const recordCount = 1000
+			for i := 0; i < recordCount; i++ {
+				// Create a record and send it.
+				record := &omnitelpb.EncodedRecord{
+					SpanCount:         uint64(i),
+					PartitionKey:      fmt.Sprintf("%05d", i),
+					UncompressedBytes: uint64(i * 10),
+				}
+				shard := config.ShardDefinitions[rand.Intn(len(config.ShardDefinitions))]
+				client.Send(record, shard)
+			}
+
+			// Wait until it arrives to the server.
+			WaitFor(t, func() bool {
+				serverRecords := server.sink.getRecords()
+				return len(serverRecords) == recordCount
+			})
+
+			// Check it arrived intact to server.
+			serverRecords := server.sink.getRecords()
+
+			// Need to sort the records because they may arrive out of order.
+			sort.Sort(byPartitionKey(serverRecords))
+
+			require.True(t, len(serverRecords) == recordCount)
+
+			for i := 0; i < recordCount; i++ {
+				record := &omnitelpb.EncodedRecord{
+					SpanCount:         uint64(i),
+					PartitionKey:      fmt.Sprintf("%05d", i),
+					UncompressedBytes: uint64(i * 10),
+				}
+				assert.EqualValues(t, record, serverRecords[i])
+			}
+
+			// Wait for client to get responses from the server.
+			WaitFor(t, func() bool {
+				return len(clientSink.getResponseToRecords()) == recordCount
+			})
+
+			// Verify that client got correct response for all records.
+			responseToRecords := clientSink.getResponseToRecords()
+
+			// Need to sort the records because they may arrive out of order.
+			sort.Sort(byPartitionKey(responseToRecords))
+
+			for i := 0; i < recordCount; i++ {
+				record := &omnitelpb.EncodedRecord{
+					SpanCount:         uint64(i),
+					PartitionKey:      fmt.Sprintf("%05d", i),
+					UncompressedBytes: uint64(i * 10),
+				}
+				assert.EqualValues(t, record, responseToRecords[i])
+			}
+
+			// Check that all responses were success.
+			responses := clientSink.getResponses()
+			for i := 0; i < len(responses); i++ {
+				response := responses[i]
+				assert.True(t, response.Id != 0)
+				assert.EqualValues(t, omnitelpb.ExportResponse_SUCCESS, response.ResultCode)
+				assert.Nil(t, response.ShardingConfig)
+			}
+		}()
+	}
+}
+
+// TODO: add tests for server closing connection, server closing stream,
+// server returning non SUCCESS responses.
+
+// clientSink is used in the tests to store responses that the client receives from
+// the server.
+type clientSink struct {
+	mutex sync.Mutex
+
+	responseToRecords []*omnitelpb.EncodedRecord
+	responses         []*omnitelpb.ExportResponse
+
+	failedRecords [][]*omnitelpb.EncodedRecord
+	failureCodes  []FailureCode
+}
+
+func (cs *clientSink) onSendResponse(responseToRecords []*omnitelpb.EncodedRecord, response *omnitelpb.ExportResponse) {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+	cs.responseToRecords = append(cs.responseToRecords, responseToRecords...)
+	cs.responses = append(cs.responses, response)
+}
+
+func (cs *clientSink) onSendFail(failedRecords []*omnitelpb.EncodedRecord, code FailureCode) {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+	cs.failedRecords = append(cs.failedRecords, failedRecords)
+	cs.failureCodes = append(cs.failureCodes, code)
+}
+
+func (cs *clientSink) getResponseToRecords() []*omnitelpb.EncodedRecord {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+	return cs.responseToRecords[:]
+}
+
+func (cs *clientSink) getResponses() []*omnitelpb.ExportResponse {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+	return cs.responses[:]
+}
+
+func setupClientServer(t *testing.T, streamCount uint, callback *clientSink) (*Client, *mockServer, *omnitelpb.ShardingConfig) {
+	// Find a local address for delivery.
+	endpoint := GetAvailableLocalAddress()
+	server := &mockServer{
+		config: createTestConfig(),
+	}
+
+	// Run a server
+	go runServer(server, endpoint)
+
+	// Create a client
+	client := NewClient(zap.NewNop())
+	cancelCh := make(chan interface{})
+
+	// Connect to the server
+	err := client.Connect(ConnectionOptions{
+		StreamCount:              streamCount,
+		Endpoint:                 endpoint,
+		StreamReopenRequestCount: 100,
+		OnSendResponse:           callback.onSendResponse,
+		OnSendFail:               callback.onSendFail,
+	}, cancelCh)
+
+	// Make sure connection succeeded.
+	require.Nil(t, err)
+
+	// Get the initial config.
+	config, err := client.GetShardingConfig()
+	require.Nil(t, err)
+	assert.EqualValues(t, server.config, config)
+
+	return client, server, config
+}

--- a/exporter/omnitelk/failurecode.go
+++ b/exporter/omnitelk/failurecode.go
@@ -1,0 +1,34 @@
+// Copyright 2019 Omnition Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package omnitelk
+
+// FailureCode describes encoding or sending failures.
+type FailureCode int
+
+const (
+	_ FailureCode = iota // skip 0 value.
+
+	// FailedEncoderStopped indicates encoding attempt when encoder is stopped.
+	FailedEncoderStopped
+
+	// FailedNotRetryable indicates that encoding or sending span data failed and
+	// it should not be retried because the problem is fatal (e.g. bad data that
+	// cannot be marshaled).
+	FailedNotRetryable
+
+	// FailedShouldRetry indicates that encoding or sending span data failed but
+	// that should be retried because the error is transient.
+	FailedShouldRetry
+)

--- a/exporter/omnitelk/mock_server.go
+++ b/exporter/omnitelk/mock_server.go
@@ -1,0 +1,136 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package omnitelk
+
+import (
+	"context"
+	"io"
+	"log"
+	"net"
+	"sync"
+
+	"google.golang.org/grpc"
+
+	omnitelpb "github.com/Omnition/omnition-opentelemetry-service/exporter/omnitelk/gen"
+)
+
+type gRPCServer struct {
+	srv       *mockServer
+	onReceive func(request *omnitelpb.ExportRequest)
+}
+
+func (s *gRPCServer) Export(stream omnitelpb.OmnitelK_ExportServer) error {
+	for {
+		// Wait for request from client.
+		request, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if request.Id == 0 {
+			log.Fatal("Received 0 Id")
+		}
+
+		// Process received request.
+		s.onReceive(request)
+
+		// Send response to client.
+		response := &omnitelpb.ExportResponse{
+			Id:             request.Id,
+			ResultCode:     s.srv.nextResponseCode,
+			ShardingConfig: s.srv.nextResponseShardingConfig,
+		}
+		if err := stream.Send(response); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *gRPCServer) GetShardingConfig(context.Context, *omnitelpb.ConfigRequest) (*omnitelpb.ShardingConfig, error) {
+	return s.srv.config, nil
+}
+
+type mockServer struct {
+	s                          *grpc.Server
+	config                     *omnitelpb.ShardingConfig
+	sink                       mockServerSink
+	nextResponseCode           omnitelpb.ExportResponse_ResultCode
+	nextResponseShardingConfig *omnitelpb.ShardingConfig
+}
+
+func (srv *mockServer) Listen(endpoint string, onReceive func(request *omnitelpb.ExportRequest)) error {
+	lis, err := net.Listen("tcp", endpoint)
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	srv.s = grpc.NewServer()
+	omnitelpb.RegisterOmnitelKServer(srv.s, &gRPCServer{srv: srv, onReceive: onReceive})
+	if err := srv.s.Serve(lis); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
+
+	return nil
+}
+
+func (srv *mockServer) Stop() {
+	srv.s.Stop()
+}
+
+func runServer(srv *mockServer, listenAddress string) {
+
+	log.Printf("Server: listening on %s", listenAddress)
+
+	if srv.config == nil {
+		srv.config = &omnitelpb.ShardingConfig{}
+	}
+
+	//totalSpans := 0
+	//prevTime := time.Now()
+
+	srv.Listen(listenAddress, func(request *omnitelpb.ExportRequest) {
+		//t := time.Now()
+		//d := t.Sub(prevTime)
+		//prevTime = t
+
+		//rate := float64(request.spanCount) / d.Seconds()
+		//
+		//totalSpans += spanCount
+		//log.Printf("Server: total spans received %v, current rate %.1f", totalSpans, rate)
+
+		srv.sink.onReceive(request)
+	})
+}
+
+type mockServerSink struct {
+	requests []*omnitelpb.ExportRequest
+	records  []*omnitelpb.EncodedRecord
+	mutex    sync.Mutex
+}
+
+func (mss *mockServerSink) onReceive(request *omnitelpb.ExportRequest) {
+	mss.mutex.Lock()
+	defer mss.mutex.Unlock()
+	mss.requests = append(mss.requests, request)
+	mss.records = append(mss.records, request.Records...)
+}
+
+func (mss *mockServerSink) getRecords() []*omnitelpb.EncodedRecord {
+	mss.mutex.Lock()
+	defer mss.mutex.Unlock()
+	return mss.records
+}

--- a/exporter/omnitelk/shard_encoder.go
+++ b/exporter/omnitelk/shard_encoder.go
@@ -34,25 +34,6 @@ const avgBatchSizeInSpans = 1000
 
 var compressedMagicByte = [8]byte{111, 109, 58, 106, 115, 112, 108, 122}
 
-// FailureCode describes encoding failures.
-type FailureCode int
-
-const (
-	_ FailureCode = iota // skip 0 value.
-
-	// FailedEncoderStopped indicates encoding attempt when encoder is stopped.
-	FailedEncoderStopped
-
-	// FailedNotRetryable indicates that encoding or sending span data failed and
-	// it should not be retried because the problem is fatal (e.g. bad data that
-	// cannot be marshaled).
-	FailedNotRetryable
-
-	// FailedShouldRetry indicates that encoding or sending span data failed but
-	// that should be retried because the error is transient.
-	FailedShouldRetry
-)
-
 // A function that accepts encoded records and the config that was used for encoding.
 type recordConsumeFunc func(record *omnitelpb.EncodedRecord, shard *shardInMemConfig)
 

--- a/exporter/omnitelk/test_helpers.go
+++ b/exporter/omnitelk/test_helpers.go
@@ -15,7 +15,9 @@
 package omnitelk
 
 import (
+	"log"
 	"math/rand"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -117,4 +119,19 @@ func GenRandByteString(len int) string {
 		b[i] = byte(rand.Intn(256))
 	}
 	return string(b)
+}
+
+// GetAvailableLocalAddress finds an available local port and returns an endpoint
+// describing it. The port is available for opening when this function returns
+// provided that there is no race by some other code to grab the same port
+// immediately.
+func GetAvailableLocalAddress() string {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		log.Fatalf("failed to get a free local port: %v", err)
+	}
+	// There is a possible race if something else takes this same port before
+	// the test uses it, however, that is unlikely in practice.
+	defer ln.Close()
+	return ln.Addr().String()
 }


### PR DESCRIPTION
Added multi-stream client implementation. This commit
includes partial test coverage, but need more tests.

TODO: add tests for server closing connection, server closing stream,
server returning non SUCCESS responses.

Task: A0-1611